### PR TITLE
Fix a coding issue

### DIFF
--- a/VIET Events/Events/VIET_events_older.txt
+++ b/VIET Events/Events/VIET_events_older.txt
@@ -3267,7 +3267,7 @@ VIETold.1045 = {
 	}
 	
 	trigger = {
-		root.faith = { has_doctrine_parameter = muhammad_succession_sunni_doctrine }
+		root.faith = { has_doctrine = muhammad_succession_sunni_doctrine }
 		#faith = { faiths_are_in_sunni_islam_group = yes }
 		NOT = { has_game_rule = VIET_conversion_universe_events }
 	}


### PR DESCRIPTION
I saw the following issue in the logs

```
[21:43:16][jomini_script_system.cpp:169]: Script system error!
  Error: has_doctrine_parameter trigger [ Bool doctrine parameter 'muhammad_succession_sunni_doctrine' does not exist ]
  Script location: file: events/VIET_events_older.txt line: 3270
```

I saw 2 times the following code in the same file so I suppose it is the way to fix the issue.
```
faith = { has_doctrine = muhammad_succession_sunni_doctrine }
```